### PR TITLE
create Splash Screen support for Android 12

### DIFF
--- a/Android-Contributions/Note-Keeping-App/app/build.gradle
+++ b/Android-Contributions/Note-Keeping-App/app/build.gradle
@@ -59,5 +59,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2-native-mt'
     implementation 'androidx.activity:activity-ktx:1.3.1'
 
+    // Splashscreen
+    implementation("androidx.core:core-splashscreen:1.0.0")
 
 }

--- a/Android-Contributions/Note-Keeping-App/app/src/main/AndroidManifest.xml
+++ b/Android-Contributions/Note-Keeping-App/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NoteKeepingApp">
+        android:theme="@style/Theme.AppSplash">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/Android-Contributions/Note-Keeping-App/app/src/main/java/com/anurag/notekeepingapp/MainActivity.kt
+++ b/Android-Contributions/Note-Keeping-App/app/src/main/java/com/anurag/notekeepingapp/MainActivity.kt
@@ -15,6 +15,7 @@ class MainActivity : AppCompatActivity(), OnTapHandler {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
 
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)

--- a/Android-Contributions/Note-Keeping-App/app/src/main/res/values/splash_theme.xml
+++ b/Android-Contributions/Note-Keeping-App/app/src/main/res/values/splash_theme.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Splash Screen Theme. -->
+    <style name="Theme.AppSplash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/white</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_logo_foreground</item>
+        <item name="windowSplashScreenAnimationDuration">2000</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat</item>
+
+        <!-- Status bar and Nav bar configs -->
+        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:navigationBarColor">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
hi @RahulKesharwani353 , I've created SplashScreen.
Tested on Android Q (API 29). It also support for Android 12.

Don't hesitate if you have feedback. Thanks!

**NOTE**: I create my own logo on the SplashScreen. If you don't mind you can use my own design to your app for free. If not, it's up to you. You can use you own logo :)

Here is the screenshot!
![SplashScreen](https://user-images.githubusercontent.com/23600466/195890951-b0288dba-cdba-4420-868a-bf744c5a48dd.png)
